### PR TITLE
feature/lfs-oid-key

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -378,7 +378,7 @@ class BlankIndex(object):
                 raise InternalError(
                     "fence not configured with data upload container; can't create signed URL"
                 )
-            container_url = "{}/{}/{}".format(container, self.guid, file_name)
+            container_url = "{}/{}".format(container, file_name)
 
             url = AzureBlobStorageIndexedFileLocation(container_url).get_signed_url(
                 "upload", expires_in
@@ -388,7 +388,7 @@ class BlankIndex(object):
                 bucket = flask.current_app.config["DATA_UPLOAD_BUCKET"]
 
             self.logger.debug("Attempting to upload to bucket '{}'".format(bucket))
-            s3_url = "s3://{}/{}/{}".format(bucket, self.guid, file_name)
+            s3_url = "s3://{}/{}".format(bucket, file_name)
             url = S3IndexedFileLocation(s3_url).get_signed_url("upload", expires_in)
 
         self.logger.info(


### PR DESCRIPTION
See

https://github.com/calypr/git-drs/issues/171

## Summary

This PR updates the object storage path structure to use the file's SHA-256 OID directly as the key, removing the GUID prefix from the storage path.

## Problem

The current implementation stores uploaded files using a path structure that includes both a GUID and the filename:
- Azure: `{container}/{guid}/{filename}`
- S3: `s3://{bucket}/{guid}/{filename}`

This approach is **incompatible with Git LFS**, which requires objects to be stored and retrieved using their **SHA-256 content hash (OID)** as the primary identifier. Git LFS expects the object key to be the content-addressed identifier itself, not a GUID-based path.

## Changes

**Modified file:** `fence/blueprints/data/indexd.py`

- **Azure Blob Storage**: Changed from `{container}/{guid}/{filename}` to `{container}/{filename}`
- **S3**: Changed from `s3://{bucket}/{guid}/{filename}` to `s3://{bucket}/{filename}`

## Why This Is Necessary for Git LFS Compatibility

Git LFS uses a **content-addressed storage model** where files are identified by their SHA-256 digest. The LFS pointer file format explicitly encodes this: oid sha256:<hex-digest>


For Git LFS to function correctly:

1. **Deterministic Object Identity**: The storage key must be derived from the file's content (SHA-256), not from arbitrary identifiers like GUIDs
2. **De-duplication**: Multiple files with identical content should map to the same storage location automatically
3. **Integrity Verification**: The object key itself serves as a content integrity check
4. **Standard Compliance**: Git LFS clients expect to retrieve objects using `oid` as the lookup key

By using the SHA-256 OID directly as the storage key (passed as `filename`), we align with Git LFS semantics and enable:
- Native Git LFS client compatibility
- Content-based de-duplication across the system
- Simpler, more deterministic object addressing

## Related Issues

See: https://github.com/calypr/git-drs/issues/171

This change implements the decision to use SHA-256 as the canonical content identifier, ensuring compatibility with Git LFS tooling and the broader content-addressed storage ecosystem.


